### PR TITLE
User ID always null, throws exception

### DIFF
--- a/src/WSOAuth.php
+++ b/src/WSOAuth.php
@@ -81,11 +81,9 @@ class WSOAuth extends AuthProviderFramework
             $email = isset($user_info['email']) ? $user_info['email'] : '';
 
             $user = User::newFromName($username);
-            $user_id = $user->getId() === 0 ? null : $user->getId();
+            $user_id = $user->idForName();
 
-            $id = $user_id === 0 ? null : $user_id;
-
-            if ($user_id !== 0 && !$this->userLoggedInThroughOAuth($id)) {
+            if (!is_null($user_id) && $user_id > 0 && !$this->userLoggedInThroughOAuth($user_id)) {
                 // The user exists and has not logged in through OAuth
                 if ($GLOBALS['wgOAuthMigrateUsersByUsername'] === false) {
                     $errorMessage = wfMessage('wsoauth-user-already-exists-message', $username)->plain();


### PR DESCRIPTION
This PR fixes an issue where the user ID will always be null and trigger an exception when checking if the user exists and has not logged in through OAuth.

If you look at the definition of [User::newFromName](https://doc.wikimedia.org/mediawiki-core/master/php/User_8php_source.html#l00539), you'll notice that an ID value for the user is never retrieved from the database and therefore is never set (it remains null).

Instead, we want to issue a request to the database to fetch the ID if it exists, using [User::idForName](https://doc.wikimedia.org/mediawiki-core/master/php/User_8php_source.html#l03457), and then check for a ID value that is greater than 0 in the case that it does exist.