### PR TITLE
Add Github provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,6 @@
   "require": {
     "mediawiki/oauthclient": "*",
     "league/oauth2-facebook": "^2.0"
+    "league/oauth2-github": "^2.0"
   }
 }

--- a/src/AuthenticationProvider/GithubAuth.php
+++ b/src/AuthenticationProvider/GithubAuth.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace AuthenticationProvider;
+
+use League\OAuth2\Client\Provider\Github;
+
+/**
+ * Class GithubAuth
+ * @package AuthenticationProvider
+ */
+class GithubAuth implements \AuthProvider
+{
+    /**
+     * @var Github
+     */
+    private $provider;
+
+    /**
+     * GithubAuth constructor.
+     */
+    public function __construct()
+    {
+        $this->provider = new Github([
+            'clientId' => $GLOBALS['wgOAuthClientId'],
+            'clientSecret' => $GLOBALS['wgOAuthClientSecret'],
+            'redirectUri' => $GLOBALS['wgOAuthRedirectUri'],
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function login(&$key, &$secret, &$auth_url)
+    {
+        $auth_url = $this->provider->getAuthorizationUrl([
+            'scope' => []
+        ]);
+
+        $secret = $this->provider->getState();
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function logout(\User &$user)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUser($key, $secret, &$errorMessage)
+    {
+        if (!isset($_GET['code'])) {
+            return false;
+        }
+
+        if (!isset($_GET['state']) || empty($_GET['state']) || ($_GET['state'] !== $secret)) {
+            return false;
+        }
+
+        try {
+            $token = $this->provider->getAccessToken('authorization_code', [
+                'code' => $_GET['code']
+            ]);
+
+            $user = $this->provider->getResourceOwner($token);
+
+            return [
+                'name' => $user->getNickname()
+            ];
+        } catch(\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveExtraAttributes($id)
+    {
+    }
+}

--- a/src/WSOAuth.php
+++ b/src/WSOAuth.php
@@ -15,6 +15,7 @@
  */
 
 use AuthenticationProvider\FacebookAuth;
+use AuthenticationProvider\GithubAuth;
 use AuthenticationProvider\MediaWikiAuth;
 use Exception\InvalidAuthProviderClassException;
 use Exception\UnknownAuthProviderException;
@@ -26,7 +27,8 @@ class WSOAuth extends AuthProviderFramework
 {
     const DEFAULT_AUTH_PROVIDERS = [
         "mediawiki" => MediaWikiAuth::class,
-        "facebook" => FacebookAuth::class
+        "facebook" => FacebookAuth::class,
+        "github" => GithubAuth::class
     ];
 
     /**


### PR DESCRIPTION
I wrote this to test out this extension; as I have the code, why not PR it :D

A few things worth mentioning:

- This is a copy of the Facebook provider, with more or less a simple search/replace on Facebook -> Github.
- The "name" is the Github Nickname, as otherwise it will show a numeric name. This Nickname can be changed in Github by the user; this is something to be aware of when using this provider.
- Realname and email are not implemented, as it requires more "scope". I don't like asking for more scope than absolutely needed, and as such, I have not.
- I did not add a copyright and license notice as with the other files. I would like to leave this up to you; it really is just a copy of facebook.